### PR TITLE
Add KoinStart to initial Koin modules in iOS

### DIFF
--- a/composeApp/src/iosMain/kotlin/org/muhammadsayed/bookstorecmp/Helper.kt
+++ b/composeApp/src/iosMain/kotlin/org/muhammadsayed/bookstorecmp/Helper.kt
@@ -1,0 +1,9 @@
+package org.muhammadsayed.bookstorecmp
+
+import org.koin.core.KoinApplication
+import org.muhammadsayed.bookstorecmp.di.start
+
+
+fun initKoin() {
+    KoinApplication.start()
+}

--- a/composeApp/src/iosMain/kotlin/org/muhammadsayed/bookstorecmp/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/org/muhammadsayed/bookstorecmp/MainViewController.kt
@@ -1,6 +1,7 @@
 package org.muhammadsayed.bookstorecmp
 
 import androidx.compose.ui.window.ComposeUIViewController
-import org.muhammadsayed.bookstorecmp.App
 
-fun MainViewController() = ComposeUIViewController { App() }
+fun MainViewController() = ComposeUIViewController {
+    App()
+}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -1,10 +1,15 @@
 import SwiftUI
+import ComposeApp
 
 @main
 struct iOSApp: App {
-	var body: some Scene {
-		WindowGroup {
-			ContentView()
-		}
-	}
+    init() {
+        HelperKt.doInitKoin()
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
 }


### PR DESCRIPTION
The application was crashing on iOS because we were not initialising the Koin module on iOS.


![Simulator Screenshot - iPhone 15 - 2024-03-06 at 20 45 41](https://github.com/abualgait/BookStoreKMP/assets/33172684/ed787f64-2e05-4ff5-b702-48813e6935fe)
